### PR TITLE
Properly expand cookbook_path

### DIFF
--- a/lib/chef/knife/cookbook_github_compare.rb
+++ b/lib/chef/knife/cookbook_github_compare.rb
@@ -55,7 +55,7 @@ class Chef
 
         @cookbook_name = parse_name_args!
 
-        @install_path = config[:cookbook_path].first
+        @install_path = File.expand_path(Array(config[:cookbook_path]).first)
 
         @repo = CookbookSCMRepoExtensions.new(@install_path, ui, config)
 

--- a/lib/chef/knife/cookbook_github_install.rb
+++ b/lib/chef/knife/cookbook_github_install.rb
@@ -69,7 +69,7 @@ class Chef
 
         parse_name_args!
 
-        @install_path = config[:cookbook_path].first
+        @install_path = File.expand_path(Array(config[:cookbook_path]).first)
         ui.info "Installing #@cookbook_name from #{github_uri} to #{@install_path}"
 
         @repo = CookbookSCMRepoExtensions.new(@install_path, ui, config)


### PR DESCRIPTION
Having something like `cookbook_path [ './cookbooks' ]` in _~.chef/knife.rb_ results in this error during `knife cookbook -V -V github install [...]`:

```
STDERR: mv: cannot move '_tmp_chef_nginx' to 'cookbooks/nginx': No such file or directory
```

[line 127 of cookbook_github_install.rb](https://github.com/nphase/knife-github-cookbooks/blob/master/lib/chef/knife/cookbook_github_install.rb#L127) triggers this error, as it runs `mv` from a temporary directory.
